### PR TITLE
QOL docker compose/docker/README changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ WORKDIR /app
 # Copy only requirements first to leverage Docker cache
 COPY requirements.txt .
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install uv && \
+    uv pip install --system --no-cache-dir -r requirements.txt
 
 # Copy project code
 # Copying app directory, alembic config, etc.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Get GuardPost up and running in minutes:
 
 3.  **Launch GuardPost:**
     ```bash
-    docker-compose up --build -d 
+    docker compose up --build -d 
     ```
 
 *(Note: For detailed instructions on manual setup without Docker, primarily intended for development, please refer to the documentation in the `docs/` directory).* 
@@ -104,9 +104,9 @@ Get GuardPost up and running in minutes:
 ## Using GuardPost
 
 *   Access the API at `http://localhost:8000`
-*   Explore the complete API documentation at `http://localhost:8000/docs`
+*   Explore the complete API documentation at `http://localhost:8000/api/v1/docs` (assuming you are using the default API_V1_STR in the .env file)
 *   Visualize your security graph at `http://localhost:7474` (Neo4j Browser - default credentials `neo4j/your_neo4j_password` or as set in `.env`)
-*   Monitor operations with `docker-compose logs -f app` or `docker-compose logs -f worker`
+*   Monitor operations with `docker compose logs -f app` or `docker compose logs -f worker`
 
 For more detailed information on architecture, workflows, and specific features, please see our **[Documentation](./docs/INDEX.md)**.
 
@@ -114,9 +114,17 @@ For more detailed information on architecture, workflows, and specific features,
 
 A Python client example (`client.py`) demonstrates GuardPost API usage:
 
-1.  Start GuardPost services with `docker-compose up`
+1.  Start GuardPost services with `docker compose up`
 2.  Configure AWS account settings in `client.py`
-3.  Set up AWS credentials in your environment
+3.  Set up AWS credentials in your environment. If modifying the `.env` file, ensure you re-run `docker compose up --build -d`
+4.  Configure python environment. Example (run at root of the repository):
+```
+python3.10 -m venv venv
+source venv/bin/activate
+pip install uv
+uv pip install -r requirements.txt
+```
+
 4.  Run the example to see GuardPost in action:
     ```bash
     python client.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:15-alpine
@@ -13,7 +11,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-guardpostpass}
       - POSTGRES_DB=${POSTGRES_DB:-guardpostdb}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-guardpost} -d $${POSTGRES_DB:-guardpostdb}"]
+      test: [ "CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-guardpost} -d $${POSTGRES_DB:-guardpostdb}" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -37,7 +35,7 @@ services:
       - NEO4J_initial_dbms_default__database=neo4j # Ensure default db name
       - NEO4J_PLUGINS=["apoc"]
     healthcheck:
-      test: ["CMD-SHELL", "wget --spider --quiet http://localhost:7474 || exit 1"]
+      test: [ "CMD-SHELL", "wget --spider --quiet http://localhost:7474 || exit 1" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -47,14 +45,14 @@ services:
     image: rabbitmq:3.12-management-alpine # Use specific version
     container_name: guardpost-rabbitmq
     ports:
-      - "5672:5672"  # AMQP
+      - "5672:5672" # AMQP
       - "15672:15672" # Management UI
     environment:
       # Default user/pass is guest/guest
       - RABBITMQ_DEFAULT_USER=${RABBITMQ_USER:-guest}
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_PASSWORD:-guest}
     healthcheck:
-      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      test: [ "CMD", "rabbitmq-diagnostics", "-q", "ping" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -66,13 +64,14 @@ services:
     ports:
       - "6379:6379"
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: [ "CMD", "redis-cli", "ping" ]
       interval: 10s
       timeout: 5s
       retries: 5
     restart: unless-stopped
 
-  app: # GuardPost Core FastAPI App
+  app:
+    # GuardPost Core FastAPI App
     container_name: guardpost-core-app
     build:
       context: .
@@ -84,12 +83,12 @@ services:
       - ./app:/app/app
       # Mount alembic for migrations if run from within container
       - ./alembic:/app/alembic
-      - ./alembic.ini:/app/alembic.ini 
+      - ./alembic.ini:/app/alembic.ini
     environment:
       # --- App Specific Settings --- #
       - APP_ENV=development # Example environment setting
       - ENABLE_LLM_REMEDIATION=${ENABLE_LLM_REMEDIATION} # Ensure this is passed from .env
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}         # Ensure this is passed from .env
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY} # Ensure this is passed from .env
       # --- JWT Settings (Read from .env) --- #
       - SECRET_KEY=${SECRET_KEY}
       - ALGORITHM=${ALGORITHM:-HS256}
@@ -111,7 +110,7 @@ services:
       # - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} # Uncomment if using temporary credentials
       # Add other required app-specific env vars
     depends_on:
-      postgres: 
+      postgres:
         condition: service_healthy
       neo4j:
         condition: service_healthy
@@ -123,7 +122,8 @@ services:
     # Run alembic upgrade first, then start uvicorn
     command: sh -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
 
-  worker: # GuardPost Core Celery Worker
+  worker:
+    # GuardPost Core Celery Worker
     container_name: guardpost-core-worker
     build:
       context: .
@@ -165,11 +165,11 @@ services:
       #   condition: service_healthy 
       # neo4j: # If tasks directly use graph DB
       #   condition: service_healthy
-    # Command to run the Celery worker
-    # Note: --reload is not standard/reliable for celery, manual restart is safer
+      # Command to run the Celery worker
+      # Note: --reload is not standard/reliable for celery, manual restart is safer
     command: celery -A app.core.celery_app worker --loglevel=INFO
 
 volumes:
   postgres_data:
   neo4j_data:
-  neo4j_logs: 
+  neo4j_logs:


### PR DESCRIPTION
- update docker-compose to docker compose
- remove version from docker-compose.yml (it's obsolete)
- fix API documentation URL in README
- use uv for python packages in Dockerfile
- add README instructions on setting up local env for using client.py
- fix various formatting